### PR TITLE
Allow passing of parameters to include. Fixes #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ engine
 app.get(function(req, res) {
   engine
     .parseAndRender("hi {{name}}", { name: "tobi" })
-    .nodeify(function(err, result) {
+    .then(function(err, result) {
       if (err) {
         res.end("ERROR: " + err);
       } else {

--- a/src/liquid/context.coffee
+++ b/src/liquid/context.coffee
@@ -76,9 +76,9 @@ module.exports = class Context
       @push(newScope)
       result = f()
 
-      if result?.nodeify?
+      if result?.then?
         popLater = true
-        result.nodeify => @pop()
+        result.then => @pop()
 
       result
     finally

--- a/src/liquid/tags/include.coffee
+++ b/src/liquid/tags/include.coffee
@@ -24,6 +24,8 @@ module.exports = class Include extends Liquid.Tag
   render: (context) ->
     attributes = @attributes
     @subTemplate.then (i) ->
-      for k, v of attributes
-        context.set k, context.resolve v
-      i.render context
+      context.stack ->
+        Promise.resolve().then ->
+          for k, v of attributes
+            context.set k, context.resolve v
+          i.render context

--- a/src/liquid/tags/include.coffee
+++ b/src/liquid/tags/include.coffee
@@ -1,6 +1,5 @@
 Liquid = require "../../liquid"
 
-
 module.exports = class Include extends Liquid.Tag
   Syntax = /([a-z0-9\/\\_-]+)/i
   SyntaxHelp = "Syntax Error in 'include' -
@@ -9,6 +8,10 @@ module.exports = class Include extends Liquid.Tag
   constructor: (template, tagName, markup, tokens) ->
     match = Syntax.exec(markup)
     throw new Liquid.SyntaxError(SyntaxHelp) unless match
+
+    @attributes = {}
+    Liquid.Helpers.scan(markup, Liquid.TagAttributes).forEach (attr) =>
+      @attributes[attr[0]] = attr[1]
 
     @filepath = match[1]
     @subTemplate = template.engine.fileSystem.readTemplateFile(@filepath)
@@ -19,4 +22,8 @@ module.exports = class Include extends Liquid.Tag
     super
 
   render: (context) ->
-    @subTemplate.then (i) -> i.render context
+    attributes = @attributes
+    @subTemplate.then (i) ->
+      for k, v of attributes
+        context.set k, context.resolve v
+      i.render context

--- a/test/fixtures/include_multiple.html
+++ b/test/fixtures/include_multiple.html
@@ -1,0 +1,1 @@
+{{name}} aged {{age}}

--- a/test/liquid.coffee
+++ b/test/liquid.coffee
@@ -58,7 +58,7 @@ describe "Liquid", ->
 
       it "parses includes with multiple local variables", ->
         @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
-        expect(@engine.parseAndRender("{% include 'fixtures/include_multiple' name: 'Josh', age: 19 %}")).to.be.fulfilled.then (output) ->
+        expect(@engine.parseAndRender("{% include 'fixtures/include_multiple', name: 'Josh', age: 19 %}")).to.be.fulfilled.then (output) ->
           expect(output).to.eq "Josh aged 19"
 
 

--- a/test/liquid.coffee
+++ b/test/liquid.coffee
@@ -25,20 +25,41 @@ describe "Liquid", ->
       expect(@engine.parse("{% for i in c %}{% endfor %}")).to.be.fulfilled.then (template) ->
         expect(template.root.nodelist[0]).to.be.instanceOf Liquid.Block
 
-    it "parses includes", ->
-      @engine.registerFileSystem new Liquid.LocalFileSystem "./"
-      expect(@engine.parse("{% include 'test/fixtures/include' %}")).to.be.fulfilled.then (template) ->
-        expect(template.root.nodelist[0]).to.be.instanceOf Liquid.Include
+    context "includes", ->
+      it "parses includes", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./"
+        expect(@engine.parse("{% include 'test/fixtures/include' %}")).to.be.fulfilled.then (template) ->
+          expect(template.root.nodelist[0]).to.be.instanceOf Liquid.Include
 
-    it "parses includes and renders the template with the correct context", ->
-      @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
-      expect(@engine.parseAndRender("{% include 'fixtures/include' %}", { name: 'Josh'})).to.be.fulfilled.then (output) ->
-        expect(output).to.eq "Josh"
+      it "parses includes and renders the template with the correct context", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/include' %}", { name: 'Josh'})).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "Josh"
 
-    it "parses nested-includes and renders the template with the correct context", ->
-      @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
-      expect(@engine.parseAndRender("{% include 'fixtures/subinclude' %}", { name: 'Josh'})).to.be.fulfilled.then (output) ->
-        expect(output).to.eq "<h1>Josh</h1>"
+      it "parses nested-includes and renders the template with the correct context", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/subinclude' %}", { name: 'Josh'})).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "<h1>Josh</h1>"
+
+      it "parses includes with local variables", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/include' name: 'Josh' %}")).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "Josh"
+
+      it "parses includes with local variables but does not pollute the current scope", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/include' name: 'Josh' %}{{name}}")).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "Josh"
+
+      it "parses nested-includes rendered with local variables", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/subinclude' name: 'Josh' %}")).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "<h1>Josh</h1>"
+
+      it "parses includes with multiple local variables", ->
+        @engine.registerFileSystem new Liquid.LocalFileSystem "./test"
+        expect(@engine.parseAndRender("{% include 'fixtures/include_multiple' name: 'Josh', age: 19 %}")).to.be.fulfilled.then (output) ->
+          expect(output).to.eq "Josh aged 19"
 
 
     it "parses complex documents", ->


### PR DESCRIPTION
I've added support for passing parameters to `include` tags. The feature itself works well, but the passed parameters pollute the parent scope.

I tried using the same `context.stack` pattern as you have in some other tags, but couldn't get it to work. Here's the code I tried:

``` coffeescript
render: (context) ->
    attributes = @attributes
    @subTemplate.then (i) ->
      context.stack =>
        Promise.resolve().then ->
          for k, v of attributes
            context.set k, context.resolve v
          i.render context
```

I wrote a test for this, couldn't get this to pass: https://github.com/codepodu/liquid-node/commit/ae145fafbe417fd1cd5f89e5a5d3cb9c934968cd#diff-ee371eceac6b854346599a46d62ca752R49

Could you help merging this in? Thanks!
